### PR TITLE
updated to .Net 9

### DIFF
--- a/LoggingKata.Test/LoggingKata.Test.csproj
+++ b/LoggingKata.Test/LoggingKata.Test.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/LoggingKata/LoggingKata.csproj
+++ b/LoggingKata/LoggingKata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to the target framework and package references in the project files for `LoggingKata` and `LoggingKata.Test`. The most important changes are:

Framework updates:
* Updated the target framework from `net6.0` to `net9.0` in `LoggingKata.Test.csproj` and `LoggingKata.csproj` [[1]](diffhunk://#diff-8f975a6b4f6a6bf082f56855ab6b958781b569ab28aec8ea2ecf984507d551a6L4-R12) [[2]](diffhunk://#diff-0f659f7d9890e5637a857299d4f1281f569506d31edd94e722e7f72f744681dbL5-R5).

Package updates:
* Updated `Microsoft.NET.Test.Sdk` from version `16.6.1` to `17.9.0` in `LoggingKata.Test.csproj`.
* Updated `xunit` from version `2.4.1` to `2.7.0` in `LoggingKata.Test.csproj`.
* Updated `xunit.runner.visualstudio` from version `2.4.1` to `2.5.7` in `LoggingKata.Test.csproj`.