### PR TITLE
updated to Net10

### DIFF
--- a/LoggingKata.Test/LoggingKata.Test.csproj
+++ b/LoggingKata.Test/LoggingKata.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/LoggingKata.Test/LoggingKata.Test.csproj
+++ b/LoggingKata.Test/LoggingKata.Test.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LoggingKata/LoggingKata.csproj
+++ b/LoggingKata/LoggingKata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates both the main project and the test project to target .NET 10.0 and upgrades the testing framework dependencies to their latest major versions. These changes help keep the codebase up-to-date with the latest .NET features and testing capabilities.

**Project and framework updates:**

* Updated the target framework in both `LoggingKata/LoggingKata.csproj` and `LoggingKata.Test/LoggingKata.Test.csproj` from `net9.0` to `net10.0` to use the latest .NET version.

**Testing dependencies:**

* Upgraded test project dependencies in `LoggingKata.Test.csproj`:
  - `Microsoft.NET.Test.Sdk` from version 17.9.0 to 18.5.0
  - Switched from `xunit` 2.x to `xunit.v3` 3.2.2
  - Updated `xunit.runner.visualstudio` from 2.5.7 to 3.1.5 and adjusted its configuration